### PR TITLE
Android: Deploy to interal on push to main; elevate to Prod on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,24 +115,16 @@ jobs:
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
 
-        # give the folders user rights -> cache restore would fail if not
-      - name: Prepare NDK dir for caching
-        run: |
-          sudo mkdir -p /usr/local/lib/android/sdk/ndk
-          sudo mkdir -p /usr/local/lib/android/sdk/platforms
-          sudo chmod -R 777 /usr/local/lib/android/sdk/ndk
-          sudo chmod -R 777 /usr/local/lib/android/sdk/platforms
-
-      # Cache Android SDK / NDK / Gradle
-      - name: Cache Android SDK, NDK, and Gradle
+      # Cache Gradle dependencies only
+      - name: Cache Gradle
         uses: actions/cache@v4
         with:
           path: |
-            /usr/local/lib/android/sdk/ndk
-            /usr/local/lib/android/sdk/platforms
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-android-sdk-${{ hashFiles('android/app/build.gradle', 'android/build.gradle') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Deps
         run: |
           rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android


### PR DESCRIPTION
This fixes #17 by automatically deploying on every push to main, and elevating on tag.
This PR also removes the SDK and NDK from the cache, as they are provided by GitHub anyway and are too large to be reasonably cached.