### PR TITLE
Upload split open source APKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,14 +139,19 @@ jobs:
           cp ./build/app/outputs/flutter-apk/app-release.apk ./apk-artifacts/app-release.apk
       - name: Prepare F-Droid Build
         run: bash scripts/prepare-fdroid-build.sh
-      - name: Build F-Droid APK
+      - name: Build F-Droid APK (split per ABI)
         run: |
           flutter clean
           flutter pub get
-          flutter build apk --release
-      - name: Save F-Droid APK
+          flutter build apk --split-per-abi --release
+      - name: Display APK sizes
         run: |
-          cp ./build/app/outputs/flutter-apk/app-release.apk ./apk-artifacts/wormhole-android-openSource.apk
+          ls -lh ./build/app/outputs/flutter-apk/app-*-release.apk
+      - name: Save F-Droid split APKs
+        run: |
+          cp ./build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk ./apk-artifacts/wormhole-android-openSource-armeabi-v7a.apk
+          cp ./build/app/outputs/flutter-apk/app-arm64-v8a-release.apk ./apk-artifacts/wormhole-android-openSource-arm64-v8a.apk
+          cp ./build/app/outputs/flutter-apk/app-x86_64-release.apk ./apk-artifacts/wormhole-android-openSource-x86_64.apk
       - name: Upload APK artifacts
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,5 +69,8 @@ jobs:
           prerelease: false
           files: |
             ./artifacts/android/app-release.apk
+            ./artifacts/android/wormhole-android-openSource-armeabi-v7a.apk
+            ./artifacts/android/wormhole-android-openSource-arm64-v8a.apk
+            ./artifacts/android/wormhole-android-openSource-x86_64.apk
             ./artifacts/windows/wormhole.zip
             ./artifacts/macos/wormhole.dmg


### PR DESCRIPTION
As mentioned in #63, this PR is needed for IzzyOnDroid to host our APKs, as the bundle is too large.
Right now, all of the builds, except arm v7a is also too large, but it's a step in the right direction.