### PR TITLE
Update android full description to correct GitLab link to GitHub

### DIFF
--- a/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/android/fastlane/metadata/android/en-US/full_description.txt
@@ -4,7 +4,7 @@ Wormhole generates a QR code or a passphrase that the recipient can use to acces
 
 The files are transfered using an end-to-end encryption, which ensures that your files are protected from prying eyes. This means that only the intended recipient can receive the files you send.
 
-Wormhole is also an open-source app, which means that the source code is available for anyone to view and contribute to. If you're interested in learning more about how Wormhole works, or if you want to contribute to its development, you can find the source code on GitLab at the link provided.
-https://gitlab.com/lukas-heiligenbrunner/wormhole
+Wormhole is also an open-source app, which means that the source code is available for anyone to view and contribute to. If you're interested in learning more about how Wormhole works, or if you want to contribute to its development, you can find the source code on GitHub at the link provided.
+https://github.com/wormhole-app/wormhole
 
 Overall, Wormhole is a powerful and user-friendly file transfer app that offers unparalleled security and ease of use. Whether you're a professional or a casual user, Wormhole is a great choice for anyone looking to share files securely.


### PR DESCRIPTION
The full description in the Android fastlane was still pointing to the gitlab link. This is now fixed.