### PR TITLE
Add code types (QR or Aztec) to translation system

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -36,6 +36,8 @@
 
     "settings_page_wordlength" : "Wortlänge:",
     "settings_page_code_type" : "Code Typ:",
+    "settings_page_qr_code" : "QR Code",
+    "settings_page_aztec_code" : "Aztec Code",
     "settings_page_show_code" : "Zeige QR Code an:",
     "settings_page_show_always" : "Immer",
     "settings_page_show_never" : "Nie",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -36,6 +36,8 @@
 
   "settings_page_wordlength" : "Word length:",
   "settings_page_code_type" : "Code Type:",
+  "settings_page_qr_code" : "QR Code",
+  "settings_page_aztec_code" : "Aztec Code",
   "settings_page_show_code" : "Show QR Code:",
   "settings_page_show_always" : "Always",
   "settings_page_show_never" : "Never",

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -150,7 +150,10 @@ class _SettingsPageState extends State<SettingsPage> {
                       ? (snapshot.data! == CodeType.qrCode ? 0 : 1)
                       : 0,
                   totalSwitches: 2,
-                  labels: const ['Qr Code', 'Aztec Code'],
+                  labels: [
+                    AppLocalizations.of(context)!.settings_page_qr_code,
+                    AppLocalizations.of(context)!.settings_page_aztec_code
+                  ],
                   radiusStyle: true,
                   onToggle: (index) {
                     Settings.setCodeType(


### PR DESCRIPTION
This pull request fixes #84 by adding localization support for the "QR Code" and "Aztec Code" labels in the settings page, ensuring that these labels are translated and displayed according to the user's selected language. The code now uses localized strings instead of hardcoded English labels.
