### PR TITLE
Add language selection feature with dropdown in settings

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -45,6 +45,8 @@
     "settings_page_dark_theme" : "Dunkel",
     "settings_page_light_theme" : "Hell",
     "settings_page_system_theme" : "System",
+    "settings_page_language" : "Sprache:",
+    "settings_page_system_language" : "System",
     "settings_page_advanced" : "Fortgeschritten:",
     "settings_page_serversettings" : "Server Einstellungen",
     "settings_page_rendezvousserver" : "Rendezvous Server:",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -45,6 +45,8 @@
   "settings_page_dark_theme" : "Dark",
   "settings_page_light_theme" : "Light",
   "settings_page_system_theme" : "System",
+  "settings_page_language" : "Language:",
+  "settings_page_system_language" : "System",
   "settings_page_advanced" : "Advanced:",
   "settings_page_serversettings" : "Server Settings",
   "settings_page_rendezvousserver" : "Rendezvous Server:",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -26,5 +26,9 @@
     "transfer_finished_label": "Fail on vastuvõetud!",
     "@transfer_finished_label": {},
     "transfer_finished_open": "Ava fail",
-    "@transfer_finished_open": {}
+    "@transfer_finished_open": {},
+    "settings_page_language": "Keel:",
+    "@settings_page_language": {},
+    "settings_page_system_language": "Süsteem",
+    "@settings_page_system_language": {}
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -43,6 +43,8 @@
   "settings_page_dark_theme": "Escuro",
   "settings_page_light_theme": "Claro",
   "settings_page_system_theme": "Sistema",
+  "settings_page_language": "Idioma:",
+  "settings_page_system_language": "Sistema",
   "settings_page_advanced": "Avançado:",
   "settings_page_serversettings": "Configurações do Servidor",
   "settings_page_rendezvousserver": "Servidor Rendezvous:",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -43,6 +43,8 @@
   "settings_page_dark_theme" : "Mörkt",
   "settings_page_light_theme" : "Ljus",
   "settings_page_system_theme" : "System",
+  "settings_page_language" : "Språk:",
+  "settings_page_system_language" : "System",
   "settings_page_advanced" : "Avancerad:",
   "settings_page_serversettings" : "Serverinställningar",
   "settings_page_rendezvousserver" : "Rendezvous Server:",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -43,6 +43,8 @@
   "settings_page_dark_theme" : "Темна",
   "settings_page_light_theme" : "Світла",
   "settings_page_system_theme" : "Системна",
+  "settings_page_language" : "Мова:",
+  "settings_page_system_language" : "Системна",
   "settings_page_advanced" : "Додатково:",
   "settings_page_serversettings" : "Налаштування сервера",
   "settings_page_rendezvousserver" : "Сервер рандеву:",

--- a/lib/locale/locale_provider.dart
+++ b/lib/locale/locale_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/cupertino.dart';
+
+import '../l10n/app_localizations.dart';
+import '../settings/settings.dart';
+
+enum LanguageType { system, de, en, et, pt, sv, uk }
+
+class LocaleProvider with ChangeNotifier {
+  // Native language names - displayed in their native form universally, and thus not localized
+  static const Map<LanguageType, String> nativeLanguageNames = {
+    LanguageType.de: 'Deutsch',
+    LanguageType.en: 'English',
+    LanguageType.et: 'Eesti',
+    LanguageType.pt: 'Português',
+    LanguageType.sv: 'Svenska',
+    LanguageType.uk: 'Українська',
+  };
+
+  static String getLanguageDisplayName(
+      LanguageType language, BuildContext context) {
+    if (language == LanguageType.system) {
+      return AppLocalizations.of(context)!.settings_page_system_language;
+    }
+    final name = nativeLanguageNames[language];
+    assert(name != null, 'Missing native language name for $language');
+    return name ?? 'Unknown language';
+  }
+
+  LanguageType _language = LanguageType.system;
+
+  LanguageType get language => _language;
+
+  set language(LanguageType language) {
+    _language = language;
+    Settings.setLanguage(language);
+    notifyListeners();
+  }
+
+  Locale? getLocale() {
+    if (_language == LanguageType.system) {
+      return null; // Let the system decide
+    }
+    return Locale(_language.name);
+  }
+}

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:toggle_switch/toggle_switch.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../../locale/locale_provider.dart';
 import '../../src/rust/api/wormhole.dart';
 import '../../settings/settings.dart';
 import '../../theme/theme_provider.dart';
@@ -114,9 +115,52 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
+  Widget _buildLanguageDropdown(
+    BuildContext context,
+    LanguageType currentLanguage,
+    LocaleProvider localeprov,
+    ThemeData theme,
+  ) {
+    final items = LanguageType.values;
+
+    final labels = {
+      for (var lang in LanguageType.values)
+        lang: LocaleProvider.getLanguageDisplayName(lang, context)
+    };
+
+    return SizedBox(
+      width: 180.0,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12.0),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.secondary,
+          borderRadius: BorderRadius.circular(15.0),
+        ),
+        child: DropdownButton<LanguageType>(
+          value: currentLanguage,
+          items: items
+              .map((language) => DropdownMenuItem(
+                    value: language,
+                    child: Text(labels[language] ?? ''),
+                  ))
+              .toList(),
+          onChanged: (LanguageType? value) {
+            if (value != null) {
+              localeprov.language = value;
+            }
+          },
+          underline: const SizedBox(),
+          isExpanded: true,
+          style: theme.textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+
   List<Widget> _buildSettingsContent() {
     final theme = Theme.of(context);
     final themeprov = Provider.of<ThemeProvider>(context);
+    final localeprov = Provider.of<LocaleProvider>(context);
 
     return [
       SettingsRow(
@@ -214,6 +258,10 @@ class _SettingsPageState extends State<SettingsPage> {
               themeprov.theme = ThemeType.values[index];
             },
           )),
+      SettingsRow(
+          name: AppLocalizations.of(context)!.settings_page_language,
+          child: _buildLanguageDropdown(
+              context, localeprov.language, localeprov, theme)),
       SettingsRow(
         name: AppLocalizations.of(context)!.settings_page_advanced,
         child: SettingsSectionButton(

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -1,5 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../locale/locale_provider.dart' show LanguageType;
 import '../theme/theme_provider.dart';
 
 enum CodeType { qrCode, aztecCode }
@@ -17,6 +18,7 @@ class Settings {
   static const _codeType = 'CODETYPE';
   static const _codeAlwaysVisible = 'CODEALVISIBLE';
   static const themeStatus = 'THEMESTATUS';
+  static const _language = 'LANGUAGE';
   static const _rendezvousUrl = 'RENDEZVOUSSERVER';
   static const _transitUrl = 'TRANSITURL';
 
@@ -42,6 +44,10 @@ class Settings {
 
   static Future<void> setTheme(ThemeType theme) async {
     await _setField(theme.index, themeStatus);
+  }
+
+  static Future<void> setLanguage(LanguageType language) async {
+    await _setField(language.index, _language);
   }
 
   static Future<String?> getRendezvousUrl() async {
@@ -83,6 +89,17 @@ class Settings {
       return ThemeType.values[idx];
     } else {
       return ThemeType.dark;
+    }
+  }
+
+  /// get current language
+  static Future<LanguageType> getLanguage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final idx = prefs.getInt(_language);
+    if (idx != null) {
+      return LanguageType.values[idx];
+    } else {
+      return LanguageType.system;
     }
   }
 


### PR DESCRIPTION
This PR fixes #74 by adding a dropdown selector in the settings, which defaults to the existing behavior (called "system"), and has all supported languages.