### PR TITLE
Add picker for download directory

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -34,6 +34,7 @@
     "settings_page_show_code": "Zeige QR Code an:",
     "settings_page_show_always": "Immer",
     "settings_page_show_never": "Nie",
+    "settings_page_ask_for_folder" : "Frage nach Download-Ordner:",
     "settings_page_theming": "App Theming:",
     "settings_page_dark_theme": "Dunkel",
     "settings_page_light_theme": "Hell",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -42,6 +42,7 @@
   "settings_page_show_code" : "Show QR Code:",
   "settings_page_show_always" : "Always",
   "settings_page_show_never" : "Never",
+  "settings_page_ask_for_folder" : "Ask for download folder:",
   "settings_page_theming" : "App Theming:",
   "settings_page_dark_theme" : "Dark",
   "settings_page_light_theme" : "Light",

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:toggle_switch/toggle_switch.dart';
 
 import '../../l10n/app_localizations.dart';
@@ -12,7 +15,6 @@ import '../../widgets/fast_future_builder.dart';
 import '../../widgets/number_input.dart';
 import '../../widgets/settings_row.dart';
 import '../../widgets/settings_section_button.dart';
-import 'package:share_plus/share_plus.dart';
 import 'server_settings_page.dart';
 
 class SettingsPage extends StatefulWidget {
@@ -25,6 +27,9 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   final _controllerWordLength = TextEditingController();
   final _exportLogsKey = GlobalKey();
+
+  bool get _showAskForFolderSetting =>
+      Platform.isAndroid || Platform.isWindows || Platform.isMacOS;
 
   @override
   void initState() {
@@ -244,6 +249,33 @@ class _SettingsPageState extends State<SettingsPage> {
               },
             ),
           )),
+      if (_showAskForFolderSetting)
+        SettingsRow(
+            name: AppLocalizations.of(context)!.settings_page_ask_for_folder,
+            child: FutureBuilder<bool>(
+              future: Settings.getAskForFolder(),
+              builder: (context, snapshot) => ToggleSwitch(
+                minWidth: 125.0,
+                cornerRadius: 15.0,
+                activeBgColors: [
+                  [theme.colorScheme.primary],
+                  [theme.colorScheme.primary]
+                ],
+                inactiveBgColor: theme.colorScheme.secondary,
+                customTextStyles: [theme.textTheme.bodyMedium],
+                initialLabelIndex:
+                    (snapshot.data ?? Defaults.askForFolder) ? 0 : 1,
+                totalSwitches: 2,
+                labels: [
+                  AppLocalizations.of(context)!.settings_page_show_always,
+                  AppLocalizations.of(context)!.settings_page_show_never
+                ],
+                radiusStyle: true,
+                onToggle: (index) {
+                  Settings.setAskForFolder(index == 0);
+                },
+              ),
+            )),
       SettingsRow(
           name: AppLocalizations.of(context)!.settings_page_theming,
           child: ToggleSwitch(

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../locale/locale_provider.dart' show LanguageType;
@@ -11,6 +13,8 @@ class Defaults {
   static CodeType get codetype => CodeType.qrCode;
 
   static bool get codeAlwaysVisible => false;
+
+  static bool get askForFolder => Platform.isWindows || Platform.isMacOS;
 }
 
 class Settings {
@@ -21,6 +25,7 @@ class Settings {
   static const _language = 'LANGUAGE';
   static const _rendezvousUrl = 'RENDEZVOUSSERVER';
   static const _transitUrl = 'TRANSITURL';
+  static const _askForFolder = 'ASKFORFOLDER';
 
   static Future<void> setRendezvousUrl(String? value) async {
     await _setField(value, _rendezvousUrl);
@@ -40,6 +45,10 @@ class Settings {
 
   static Future<void> setCodeAlwaysVisible(bool value) async {
     await _setField(value, _codeAlwaysVisible);
+  }
+
+  static Future<void> setAskForFolder(bool value) async {
+    await _setField(value, _askForFolder);
   }
 
   static Future<void> setTheme(ThemeType theme) async {
@@ -79,6 +88,11 @@ class Settings {
   static Future<bool> getCodeAlwaysVisible() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_codeAlwaysVisible) ?? Defaults.codeAlwaysVisible;
+  }
+
+  static Future<bool> getAskForFolder() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_askForFolder) ?? Defaults.askForFolder;
   }
 
   /// get current theme : true if darkmode

--- a/lib/transfer/transfer_receiver.dart
+++ b/lib/transfer/transfer_receiver.dart
@@ -141,7 +141,8 @@ class _TransferReceiverState extends State<TransferReceiver> {
   }
 
   void _receiveFile(String passphrase) async {
-    final dpath = await getDownloadPath();
+    final dpath =
+        await getDownloadPath(askForFolder: await Settings.getAskForFolder());
     if (dpath == null) {
       AppLogger.warn('No download path available');
       return;

--- a/lib/utils/paths.dart
+++ b/lib/utils/paths.dart
@@ -1,9 +1,27 @@
 import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'logger.dart';
 
-Future<String?> getDownloadPath() async {
+bool _canAskForDownloadFolder() =>
+    Platform.isAndroid || Platform.isWindows || Platform.isMacOS;
+
+Future<String?> getDownloadPath({bool askForFolder = false}) async {
+  if (askForFolder && _canAskForDownloadFolder()) {
+    try {
+      final selectedDirectory = await FilePicker.getDirectoryPath();
+      if (selectedDirectory != null) {
+        return selectedDirectory;
+      }
+      AppLogger.info('Download folder selection cancelled');
+      return null;
+    } catch (err) {
+      AppLogger.error('Cannot select download folder path: $err');
+      return null;
+    }
+  }
+
   Directory? directory;
   try {
     if (Platform.isIOS) {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,7 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <gtk/gtk_plugin.h>
-#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
-#include <window_manager/window_manager_plugin.h>
-#include <yaru_window_linux/yaru_window_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
@@ -20,16 +17,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
-  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
-  g_autoptr(FlPluginRegistrar) window_manager_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
-  window_manager_plugin_register_with_registrar(window_manager_registrar);
-  g_autoptr(FlPluginRegistrar) yaru_window_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "YaruWindowLinuxPlugin");
-  yaru_window_linux_plugin_register_with_registrar(yaru_window_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,10 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   gtk
-  screen_retriever_linux
   url_launcher_linux
-  window_manager
-  yaru_window_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,11 +11,9 @@ import file_picker
 import file_selector_macos
 import mobile_scanner
 import path_provider_foundation
-import screen_retriever_macos
 import share_plus
 import shared_preferences_foundation
 import url_launcher_macos
-import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
@@ -24,9 +22,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
-  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,10 +9,8 @@
 #include <app_links/app_links_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
-#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
-#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
@@ -21,12 +19,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
-  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
-  WindowManagerPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,10 +6,8 @@ list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   file_selector_windows
   permission_handler_windows
-  screen_retriever_windows
   share_plus
   url_launcher_windows
-  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
This PR addresses issue #148 by adding an optional picker for the download directory for Android, macOS and Windows.
As far as I know, on iOS, this isn't easily possible because of permissions issues.